### PR TITLE
Add multizone base path support

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,13 @@
 import type { NextConfig } from 'next';
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH !== undefined
+  ? process.env.NEXT_PUBLIC_BASE_PATH
+  : '/us/salternative';
+
+
 const nextConfig: NextConfig = {
+  ...(basePath ? { basePath } : {}),
+  env: { NEXT_PUBLIC_BASE_PATH: basePath },
   // Mantine ships CJS interop; transpiling avoids ESM/CJS mismatch errors.
   transpilePackages: ['@mantine/core', '@mantine/hooks'],
   turbopack: {

--- a/frontend/src/hooks/useNationwideImpacts.ts
+++ b/frontend/src/hooks/useNationwideImpacts.ts
@@ -94,7 +94,7 @@ export function useNationwideImpacts(): NationwideImpactsData & {
     async function loadData() {
       try {
         // Load single year impacts
-        const singleYearResponse = await fetch('/data/impacts_2026.json');
+        const singleYearResponse = await fetch(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/impacts_2026.json`);
         if (singleYearResponse.ok) {
           const singleYearData: ImpactRecord[] = await singleYearResponse.json();
           setSingleYearImpacts(singleYearData.map(parseImpactRecord));


### PR DESCRIPTION
Adds a production base path for the PolicyEngine multizone mount and keeps local/root builds available with `NEXT_PUBLIC_BASE_PATH=` where the app uses Next.js.

Also prefixes root-relative public data/assets where needed so the zone loads correctly behind `policyengine.org` instead of only passing a framework build.

Verification:
- `git diff --check`