### PR TITLE
Fix mounted data asset paths

### DIFF
--- a/frontend/src/hooks/useNationwideImpacts.ts
+++ b/frontend/src/hooks/useNationwideImpacts.ts
@@ -103,7 +103,7 @@ export function useNationwideImpacts(): NationwideImpactsData & {
         // Load budget window impacts (2026-2035)
         const budgetMap = new Map<number, ParsedImpact[]>();
         for (let year = 2026; year <= 2035; year++) {
-          const response = await fetch(`/data/impacts_${year}.json`);
+          const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/impacts_${year}.json`);
           if (response.ok) {
             const yearData: ImpactRecord[] = await response.json();
             budgetMap.set(year, yearData.map(parseImpactRecord));


### PR DESCRIPTION
## Summary

- Prefix SALT AMT budget-window data fetches with `NEXT_PUBLIC_BASE_PATH`.

## Root cause

One data fetch path still used `/data/...` after the multizone base path PR, so mounted deployments requested policyengine.org root data files.

## Verification

- `git diff --check`
- Live probe: `/us/salternative/data/impacts_2026.json` returns 200; `/data/impacts_2026.json` returns 404.
