### PR TITLE
Use shared PolicyEngine shell header

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -8,7 +8,7 @@
         "@emotion/react": "^11.14.0",
         "@mantine/core": "^8.3.10",
         "@mantine/hooks": "^8.3.10",
-        "@policyengine/ui-kit": "^0.9.0",
+        "@policyengine/ui-kit": "^0.10.1",
         "@tabler/icons-react": "^3.36.0",
         "next": "^16.2.6",
         "react": "^19.2.0",
@@ -264,7 +264,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.128.0", "", {}, "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ=="],
 
-    "@policyengine/ui-kit": ["@policyengine/ui-kit@0.9.0", "", { "dependencies": { "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "cmdk": "^1.1.1", "d3-geo": "^3.1.0", "dayjs": "^1.11.13", "lucide-react": "^0.577.0", "radix-ui": "^1.4.3", "tailwind-merge": "^3.5.0", "tw-animate-css": "^1.4.0" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19", "recharts": ">=2.12" } }, "sha512-oPqMSr+qSdY/63xZ8b7dO3q5Bhceg5UQCiZ/m4tOqcywviQk5VO8FKzkUR8pzmFIv8Q4TB3b2OB0ZKfo6UzHQw=="],
+    "@policyengine/ui-kit": ["@policyengine/ui-kit@0.10.1", "", { "dependencies": { "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "cmdk": "^1.1.1", "d3-geo": "^3.1.0", "dayjs": "^1.11.13", "lucide-react": "^0.577.0", "radix-ui": "^1.4.3", "tailwind-merge": "^3.5.0", "tw-animate-css": "^1.4.0" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19", "recharts": ">=2.12" } }, "sha512-9sOVLaMtMOJcgmUQIlqViTkodhazuwMEkPVoPU+mrnZidCk6CChsSP0R55uVR8yInEDLtXZzgT/CCL8FsZ5uJQ=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "@emotion/react": "^11.14.0",
     "@mantine/core": "^8.3.10",
     "@mantine/hooks": "^8.3.10",
-    "@policyengine/ui-kit": "^0.9.0",
+    "@policyengine/ui-kit": "^0.10.1",
     "@tabler/icons-react": "^3.36.0",
     "next": "^16.2.6",
     "react": "^19.2.0",

--- a/frontend/src/components/PolicyEngineHeader.tsx
+++ b/frontend/src/components/PolicyEngineHeader.tsx
@@ -1,37 +1,11 @@
 "use client";
 
-import { Header } from "@policyengine/ui-kit";
-
-const navItems = [
-  { label: "Research", href: "https://policyengine.org/us/research" },
-  { label: "Model", href: "https://policyengine.org/us/model" },
-  { label: "API", href: "https://policyengine.org/us/api" },
-  {
-    label: "About",
-    href: "https://policyengine.org/us/team",
-    children: [
-      { label: "Team", href: "https://policyengine.org/us/team" },
-      { label: "Supporters", href: "https://policyengine.org/us/supporters" },
-    ],
-  },
-  { label: "Donate", href: "https://policyengine.org/us/donate" },
-];
-
-const countries = [
-  { id: "us", label: "United States" },
-  { id: "uk", label: "United Kingdom" },
-];
+import { PolicyEngineHeader as ShellHeader } from "@policyengine/ui-kit/layout";
 
 export default function PolicyEngineHeader() {
   return (
-    <Header
-      navItems={navItems}
-      countries={countries}
-      currentCountry="us"
-      logoHref="https://policyengine.org/us"
-      onCountryChange={(countryId) => {
-        window.location.href = `https://policyengine.org/${countryId}`;
-      }}
-    />
+    <div aria-label="PolicyEngine site header">
+      <ShellHeader country="us" />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the local ad hoc header with @policyengine/ui-kit/layout's PolicyEngineHeader
- update ui-kit to 0.10.1 so the header uses the published shell client boundary
- expose an accessible top-shell label for auditability

## Verification
- bun run lint (existing warnings only)
- bun run build