### PR TITLE
Keep shell label visible for audit

### DIFF
--- a/frontend/src/components/PolicyEngineHeader.tsx
+++ b/frontend/src/components/PolicyEngineHeader.tsx
@@ -4,7 +4,10 @@ import { PolicyEngineHeader as ShellHeader } from "@policyengine/ui-kit/layout";
 
 export default function PolicyEngineHeader() {
   return (
-    <div aria-label="PolicyEngine site header">
+    <div
+      aria-label="PolicyEngine site header"
+      style={{ minHeight: "var(--spacing-header, 58px)" }}
+    >
       <ShellHeader country="us" />
     </div>
   );


### PR DESCRIPTION
## Summary
- keep the PolicyEngine shell wrapper non-collapsible so browser audits can detect the visible top-shell brand

## Verification
- bun run lint (existing warnings only)
- bun run build