### PR TITLE
Test SALT shell header order

### DIFF
--- a/frontend/src/app/AppClient.test.tsx
+++ b/frontend/src/app/AppClient.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import AppClient from './AppClient';
+
+vi.mock('@policyengine/ui-kit/layout', () => ({
+  PolicyEngineHeader: () => (
+    <div aria-label="PolicyEngine site header">
+      <span>PolicyEngine</span>
+      <nav>Research Model API Donate</nav>
+    </div>
+  ),
+}));
+
+vi.mock('@/hooks/useUrlSync', () => ({
+  useUrlSync: vi.fn(),
+}));
+
+vi.mock('@/components/layout/SlideContainer', () => ({
+  SlideContainer: () => <main>Slide content</main>,
+}));
+
+vi.mock('@/components/layout/SlideNavigation', () => ({
+  SlideNavigation: () => <nav>Slide navigation</nav>,
+}));
+
+vi.mock('@/components/layout/NotesFooter', () => ({
+  NotesFooter: () => <footer>Notes</footer>,
+}));
+
+vi.mock('@/components/inputs/HouseholdInputs', () => ({
+  HouseholdInputs: () => <section>Household inputs</section>,
+}));
+
+vi.mock('@/components/inputs/PolicyConfigInputs', () => ({
+  PolicyConfigInputs: () => <section>Policy inputs</section>,
+}));
+
+describe('AppClient shell', () => {
+  it('renders the shared PolicyEngine shell before the SALT toolbar', () => {
+    render(<AppClient />);
+
+    const appHeader = document.querySelector('header');
+    const policyEngineHeader = screen.getAllByLabelText('PolicyEngine site header')[0];
+    const saltTitle = screen.getByText('SALTernative');
+
+    expect(appHeader).toContainElement(policyEngineHeader);
+    expect(appHeader).toContainElement(saltTitle);
+    expect(policyEngineHeader.compareDocumentPosition(saltTitle)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(appHeader?.firstElementChild).toBe(policyEngineHeader);
+  });
+});


### PR DESCRIPTION
## Summary
- add an AppClient component test that locks the shared PolicyEngine site header before the SALT calculator toolbar
- mock heavy slide/input children so the test focuses only on shell placement

## Verification
- cd frontend && bun run test src/app/AppClient.test.tsx
- cd frontend && bun run lint
- cd frontend && bun run test
- cd frontend && bun run build
- git diff --check