### PR TITLE
Wrap layout with @policyengine/ui-kit PolicyEngineShell

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -8,7 +8,7 @@
         "@emotion/react": "^11.14.0",
         "@mantine/core": "^8.3.10",
         "@mantine/hooks": "^8.3.10",
-        "@policyengine/ui-kit": "^0.10.1",
+        "@policyengine/ui-kit": "^0.12.0",
         "@tabler/icons-react": "^3.36.0",
         "next": "^16.2.6",
         "react": "^19.2.0",
@@ -264,7 +264,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.128.0", "", {}, "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ=="],
 
-    "@policyengine/ui-kit": ["@policyengine/ui-kit@0.10.1", "", { "dependencies": { "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "cmdk": "^1.1.1", "d3-geo": "^3.1.0", "dayjs": "^1.11.13", "lucide-react": "^0.577.0", "radix-ui": "^1.4.3", "tailwind-merge": "^3.5.0", "tw-animate-css": "^1.4.0" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19", "recharts": ">=2.12" } }, "sha512-9sOVLaMtMOJcgmUQIlqViTkodhazuwMEkPVoPU+mrnZidCk6CChsSP0R55uVR8yInEDLtXZzgT/CCL8FsZ5uJQ=="],
+    "@policyengine/ui-kit": ["@policyengine/ui-kit@0.12.0", "", { "dependencies": { "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "cmdk": "^1.1.1", "d3-geo": "^3.1.0", "dayjs": "^1.11.13", "lucide-react": "^0.577.0", "radix-ui": "^1.4.3", "tailwind-merge": "^3.5.0", "tw-animate-css": "^1.4.0" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19", "recharts": ">=2.12" } }, "sha512-Psz6j9ykKjGzrvEHR2Evv1EbOS/H7eBM5iydd7GfxCD2eQgu6uMWw2sLZXNFfmhKKDxevheynnaATcKJOw5QGQ=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "@emotion/react": "^11.14.0",
     "@mantine/core": "^8.3.10",
     "@mantine/hooks": "^8.3.10",
-    "@policyengine/ui-kit": "^0.10.1",
+    "@policyengine/ui-kit": "^0.12.0",
     "@tabler/icons-react": "^3.36.0",
     "next": "^16.2.6",
     "react": "^19.2.0",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,3 +1,6 @@
+import { PolicyEngineShell } from "@policyengine/ui-kit/layout";
+import "@policyengine/ui-kit/styles.css";
+
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 
@@ -43,7 +46,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        <PolicyEngineShell country="us">
         {children}
+              </PolicyEngineShell>
       </body>
     </html>
   );


### PR DESCRIPTION
Wraps the app's root layout with `<PolicyEngineShell country="us">` from `@policyengine/ui-kit ^0.12.0` so policyengine.org/us/* renders the PolicyEngine site header + footer around this tool. Adds the ui-kit dependency. Layout edit is mechanical and idempotent.